### PR TITLE
use 10.8 MACOSX_DEPLOYMENT_TARGET for future_error

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -13,7 +13,7 @@
                 { "xcode_settings": {
                     'OTHER_CPLUSPLUSFLAGS' : ['-std=c++11','-stdlib=libc++'],
                     'OTHER_LDFLAGS': ['-stdlib=libc++'],
-                    'MACOSX_DEPLOYMENT_TARGET': '10.7'
+                    'MACOSX_DEPLOYMENT_TARGET': '10.8'
                 }}
             ]
         ]


### PR DESCRIPTION
trying to run make on my macOS Sierra would fail with the attached error.

i have updated the OSX deployment target so that this should compile now (but will still give out ForceSet deprecation warnings)

<details><summary>future_error error</summary>
```/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/future:1447:23: error:
      'future_error' is unavailable: introduced in macOS 10.8
                      future_error(make_error_code(future_errc::broken_promise))
                      ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/future:502:63: note:
      'future_error' has been explicitly marked unavailable here
class _LIBCPP_EXCEPTION_ABI _LIBCPP_AVAILABILITY_FUTURE_ERROR future_error
                                                              ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/future:1621:23: error:
      'future_error' is unavailable: introduced in macOS 10.8
                      future_error(make_error_code(future_errc::broken_promise))
                      ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/future:502:63: note:
      'future_error' has been explicitly marked unavailable here
class _LIBCPP_EXCEPTION_ABI _LIBCPP_AVAILABILITY_FUTURE_ERROR future_error
                                                              ^
../src/mmap-io.cc:246:29: warning: 'ForceSet' is deprecated [-Wdeprecated-declarations]
                   exports->ForceSet(Nan::New(key).ToLocalChecked(), Nan::New(val), property_attrs);
                            ^
/Users/arrayjam/.node-gyp/7.7.1/include/node/v8.h:2956:22: note: 'ForceSet' has been explicitly marked deprecated here
                bool ForceSet(Local<Value> key, Local<Value> value,
                     ^
../src/mmap-io.cc:282:22: warning: 'ForceSet' is deprecated [-Wdeprecated-declarations]
            exports->ForceSet(Nan::New("map").ToLocalChecked(), Nan::New<FunctionTemplate>(mmap_map)->GetFunction(), property_attrs);
                     ^
/Users/arrayjam/.node-gyp/7.7.1/include/node/v8.h:2956:22: note: 'ForceSet' has been explicitly marked deprecated here
                bool ForceSet(Local<Value> key, Local<Value> value,
                     ^
../src/mmap-io.cc:283:22: warning: 'ForceSet' is deprecated [-Wdeprecated-declarations]
            exports->ForceSet(Nan::New("advise").ToLocalChecked(), Nan::New<FunctionTemplate>(mmap_advise)->GetFunction(), prope...
                     ^
/Users/arrayjam/.node-gyp/7.7.1/include/node/v8.h:2956:22: note: 'ForceSet' has been explicitly marked deprecated here
                bool ForceSet(Local<Value> key, Local<Value> value,
                     ^
../src/mmap-io.cc:284:22: warning: 'ForceSet' is deprecated [-Wdeprecated-declarations]
            exports->ForceSet(Nan::New("incore").ToLocalChecked(), Nan::New<FunctionTemplate>(mmap_incore)->GetFunction(), prope...
                     ^
/Users/arrayjam/.node-gyp/7.7.1/include/node/v8.h:2956:22: note: 'ForceSet' has been explicitly marked deprecated here
                bool ForceSet(Local<Value> key, Local<Value> value,
                     ^
../src/mmap-io.cc:288:22: warning: 'ForceSet' is deprecated [-Wdeprecated-declarations]
            exports->ForceSet(Nan::New("sync_lib_private__").ToLocalChecked(), Nan::New<FunctionTemplate>(mmap_sync_lib_private_...
                     ^
/Users/arrayjam/.node-gyp/7.7.1/include/node/v8.h:2956:22: note: 'ForceSet' has been explicitly marked deprecated here
                bool ForceSet(Local<Value> key, Local<Value> value,
                     ^
5 warnings and 2 errors generated.
make[1]: *** [Release/obj.target/mmap-io/src/mmap-io.o] Error 1```
</details>
