### PR TITLE
Windows fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,23 +17,19 @@
     "bugs": {
         "url" : "http://github.com/ozra/mmap-io/issues"
     },
-
     "scripts": {
-        "prepublish":   "make ls",
+        "prepare":      "lsc -b -c -o ./ src/mmap-io.ls src/test.ls",
         "install":      "node-gyp configure && node-gyp rebuild",
         "test":         "node ./test.js"
     },
-
     "devDependencies": {
         "errno": "*",
         "LiveScript": "1.*.*"
     },
-
     "dependencies": {
         "bindings": "1.*.*",
         "nan":      "2.*.*"
     },
-
     "main":     "mmap-io",
     "engines": {
         "node": ">=0.10.0"

--- a/src/mman.h
+++ b/src/mman.h
@@ -50,11 +50,11 @@ inline void* mmap(void* addr, size_t length, int prot, int flags, int fd, off_t 
 
     off_t end = length + offset;
     const DWORD dwEndLow = (sizeof(off_t) > sizeof(DWORD)) ? DWORD(end & 0xFFFFFFFFL) : DWORD(end);
-    const DWORD dwEndHigh = (sizeof(off_t) > sizeof(DWORD)) ? DWORD(end & 0xFFFFFFFFL) : DWORD(0);
+    const DWORD dwEndHigh = (sizeof(off_t) > sizeof(DWORD)) ? DWORD((end >> 32) & 0xFFFFFFFFL) : DWORD(0);
     const DWORD dwOffsetLow = (sizeof(off_t) > sizeof(DWORD)) ? DWORD(offset & 0xFFFFFFFFL) : DWORD(offset);
-    const DWORD dwOffsetHigh = (sizeof(off_t) > sizeof(DWORD)) ? DWORD(offset & 0xFFFFFFFFL) : DWORD(0);
+    const DWORD dwOffsetHigh = (sizeof(off_t) > sizeof(DWORD)) ? DWORD((offset >> 32) & 0xFFFFFFFFL) : DWORD(0);
 
-    HANDLE h = (fd == -1) ? HANDLE(_get_osfhandle(fd)) : INVALID_HANDLE_VALUE;
+    HANDLE h = (fd != -1) ? HANDLE(uv_get_osfhandle(fd)) : INVALID_HANDLE_VALUE;
     HANDLE fm = CreateFileMapping(h, nullptr, protect, dwEndHigh, dwEndLow, nullptr);
     if (fm == nullptr)
         return MAP_FAILED;
@@ -93,4 +93,9 @@ inline int msync(void* addr, size_t length, int flags) {
 
 inline int madvise(void* addr, size_t length, int advice) {
     return 0;   // Unsupported on Windows
+}
+
+inline int mincore(void *addr, size_t length, unsigned char *vec) {
+    errno = ENOSYS;
+    return -1;
 }

--- a/src/mmap-io.cc
+++ b/src/mmap-io.cc
@@ -183,10 +183,13 @@ JS_FN(mmap_incore) {
             }
 
             int ret = mincore(data, size, resultData);
-
             if (ret) {
                 free(resultData);
-                return Nan::ThrowError((std::string("mincore() failed, ") + std::to_string(errno)).c_str());
+                if (errno == ENOSYS) {
+                  return Nan::ThrowError("mincore() not implemented");
+                } else {
+                  return Nan::ThrowError((std::string("mincore() failed, ") + std::to_string(errno)).c_str());
+                }
             }
 
             // Now we want to check all of the pages


### PR DESCRIPTION
Changes all related to Windows port:
- Fixes for issues #5 and issue #6.   Tested on Win10/Node 8.9.1 and Win10/Electron 1.8.3beta.3
- Updated package.json to stop using a deprecated 'prepublish' script name (see https://docs.npmjs.com/misc/scripts#deprecation-note)
- skip tests which will aways fail on Windows due to OS behavior (see comment in test.ls)
- added missing stub for mincore() on Windows and better error checking in common code

Note that fixing issue #6 requires a relatively new Node version.  For details see https://github.com/nodejs/node/issues/6369 and https://github.com/libuv/libuv/issues/1291