### PR TITLE
fix compile errors and don't require global LiveScript

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,12 @@ human_errors:
 ls: $(LS_SRC_FILES:src/%.ls=%.js)
 
 %.js: src/%.ls
+ifeq ($(shell test -e ../../$(LSC) && echo -n yes),yes)
+	echo "using parent's LiveScript"
+	../../$(LSC) -b -c $< -o ./
+else
 	$(LSC) -b -c $< -o ./
+endif
 
 clean:
 	rm -rf build *.js

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ human_errors:
 ls: $(LS_SRC_FILES:src/%.ls=%.js)
 
 %.js: src/%.ls
-ifeq ($(shell test -e ../../$(LSC) && echo -n yes),yes)
+ifeq ($(shell test -e ../../$(LSC) && echo -n yes),yes) #uses info from https://stackoverflow.com/questions/5553352/how-do-i-check-if-file-exists-in-makefile
 	echo "using parent's LiveScript"
 	../../$(LSC) -b -c $< -o ./
 else

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "scripts": {
         "prepublish":   "make ls",
         "install":      "node-gyp configure && node-gyp rebuild",
-        "test":         "node ./test.js"
+    "postinstall": "make ls",
+    "test":         "node ./test.js"
     },
 
     "devDependencies": {
@@ -31,6 +32,7 @@
 
     "dependencies": {
         "bindings": "1.*.*",
+        "LiveScript": "1.*.*",
         "nan":      "2.*.*"
     },
 

--- a/src/mmap-io.cc
+++ b/src/mmap-io.cc
@@ -243,7 +243,8 @@ void Init(Handle<Object> exports, Handle<Object> module) {
             constexpr auto property_attrs = static_cast<PropertyAttribute>(ReadOnly | DontDelete);
 
             auto set_prop = [&](const char* key, int val) -> void {
-                   exports->ForceSet(Nan::New(key).ToLocalChecked(), Nan::New(val), property_attrs);
+//                   exports->ForceSet(Nan::New(key).ToLocalChecked(), Nan::New(val), property_attrs);
+                   Nan::ForceSet(exports, Nan::New(key).ToLocalChecked(), Nan::New(val), property_attrs);
             };
 
             set_prop("PROT_READ", PROT_READ);
@@ -279,13 +280,17 @@ void Init(Handle<Object> exports, Handle<Object> module) {
             set_prop("PAGESIZE", sysconf(_SC_PAGESIZE));
 #endif
 
-            exports->ForceSet(Nan::New("map").ToLocalChecked(), Nan::New<FunctionTemplate>(mmap_map)->GetFunction(), property_attrs);
-            exports->ForceSet(Nan::New("advise").ToLocalChecked(), Nan::New<FunctionTemplate>(mmap_advise)->GetFunction(), property_attrs);
-            exports->ForceSet(Nan::New("incore").ToLocalChecked(), Nan::New<FunctionTemplate>(mmap_incore)->GetFunction(), property_attrs);
+//            exports->ForceSet(Nan::New("map").ToLocalChecked(), Nan::New<FunctionTemplate>(mmap_map)->GetFunction(), property_attrs);
+//            exports->ForceSet(Nan::New("advise").ToLocalChecked(), Nan::New<FunctionTemplate>(mmap_advise)->GetFunction(), property_attrs);
+//            exports->ForceSet(Nan::New("incore").ToLocalChecked(), Nan::New<FunctionTemplate>(mmap_incore)->GetFunction(), property_attrs);
+            Nan::ForceSet(exports, Nan::New("map").ToLocalChecked(), Nan::New<FunctionTemplate>(mmap_map)->GetFunction(), property_attrs);
+            Nan::ForceSet(exports, Nan::New("advise").ToLocalChecked(), Nan::New<FunctionTemplate>(mmap_advise)->GetFunction(), property_attrs);
+            Nan::ForceSet(exports, Nan::New("incore").ToLocalChecked(), Nan::New<FunctionTemplate>(mmap_incore)->GetFunction(), property_attrs);
 
             // This one is wrapped by a JS-function and deleted from obj to hide from user
             // *TODO* perhaps call is sync so that we simply can drop in to the sync-name in JS, no deleting
-            exports->ForceSet(Nan::New("sync_lib_private__").ToLocalChecked(), Nan::New<FunctionTemplate>(mmap_sync_lib_private_)->GetFunction(), PropertyAttribute::None);
+//            exports->ForceSet(Nan::New("sync_lib_private__").ToLocalChecked(), Nan::New<FunctionTemplate>(mmap_sync_lib_private_)->GetFunction(), PropertyAttribute::None);
+            Nan::ForceSet(exports, Nan::New("sync_lib_private__").ToLocalChecked(), Nan::New<FunctionTemplate>(mmap_sync_lib_private_)->GetFunction(), PropertyAttribute::None);
 
 }
 


### PR DESCRIPTION
fixed a couple of problems:
1. mmap-io.cc did not compile with recent Node.js (6.2.x or later)
2. Either .gitignore should not list mmap-io.js or a global copy of LiveScript should not be required (in case user doesn't already have LiveScript installed)