### PR TITLE
Enable worker support

### DIFF
--- a/src/mmap-io.cc
+++ b/src/mmap-io.cc
@@ -373,4 +373,4 @@ NAN_MODULE_INIT(Init) {
 
 }
 
-NODE_MODULE(mmap_io, Init)
+NAN_MODULE_WORKER_ENABLED(mmap_io, Init);


### PR DESCRIPTION
Switching the declaration is all that's needed to use mmap-io
inside Workers (with node >= 10.*), because the library has no
static or global data.